### PR TITLE
fix spelling of "active" in task

### DIFF
--- a/tasks/system_settings/system_accounting_with_auditd.yml
+++ b/tasks/system_settings/system_accounting_with_auditd.yml
@@ -411,7 +411,7 @@
   lineinfile:
     dest: /etc/audisp/plugins.d/syslog.conf
     line: active = yes
-    regexp: '.*acitve.*'
+    regexp: '.*active.*'
   when: ansible_distribution_major_version == "7"
   tags:
   - AU


### PR DESCRIPTION
This resolves [issue #22 ](https://github.com/rhtps/ansible-role-800-53/issues/22)