### PR TITLE
remove erroneous \t characters from task

### DIFF
--- a/tasks/system_settings/account_and_access_control/protect_accounts_by_configuring_pam.yml
+++ b/tasks/system_settings/account_and_access_control/protect_accounts_by_configuring_pam.yml
@@ -346,5 +346,5 @@
 - name: Set Last Login/Access Notification
   lineinfile:
     dest: /etc/pam.d/system-auth
-    line: "session\t    required\t  pam_lastlog.so showfailed"
+    line: "session    required  pam_lastlog.so showfailed"
     state: present


### PR DESCRIPTION
This should resolve the problem noted in [issue #24 ](https://github.com/rhtps/ansible-role-800-53/issues/24)