### PR TITLE
Changes based on updated STIG xccdf profiles in RHEL6/7

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ vpn_package: openswan
 #Whether or not to run an SCAP scan
 run_scap: true
 #The profile to run
-scap_profile:
+scap_profile_6:
   - stig-rhel{{ ansible_distribution_major_version }}-server-upstream
+scap_profile_7:
+  - stig-rhel{{ ansible_distribution_major_version }}-disa
 #Where on your local host you wish to place the reports
 scap_reports_dir: /tmp
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,8 +26,10 @@ executables_path:
 vpn_package: openswan
 
 run_scap: true
-scap_profile:
+scap_profile_6:
 - stig-rhel{{ ansible_distribution_major_version }}-server-upstream
+scap_profile_7:
+- stig-rhel{{ ansible_distribution_major_version }}-disa
 
 scap_reports_dir: /tmp
 

--- a/tasks/scap.yml
+++ b/tasks/scap.yml
@@ -65,7 +65,7 @@
   command: /usr/bin/oscap xccdf eval --profile "{{ item }}" --results /tmp/scap_reports/scan-xccdf-results-{{ ansible_date_time.iso8601  }}-{{ item }}.xml --fetch-remote-resources --report /tmp/scap_reports/scan-xccdf-report-{{ ansible_date_time.iso8601  }}-{{ item }}.html  /usr/share/xml/scap/ssg/content/ssg-rhel{{ ansible_distribution_major_version }}-xccdf.xml
   failed_when: "result | failed and 'This content points out to the remote resources' not in result.stdout"
   register: result
-  with_items: "{{ scap_profile }}"
+  with_items: "{{ scap_profile_6 }}"
   when: run_scap and ansible_distribution_major_version == "6"
   tags:
     - scap
@@ -74,7 +74,7 @@
   command: /usr/bin/oscap xccdf eval --profile "{{ item }}" --results /tmp/scap_reports/scan-xccdf-results-{{ ansible_date_time.iso8601  }}-{{ item }}.xml --fetch-remote-resources --report /tmp/scap_reports/scan-xccdf-report-{{ ansible_date_time.iso8601  }}-{{ item }}.html  /usr/share/xml/scap/ssg/content/ssg-rhel{{ ansible_distribution_major_version }}-xccdf.xml
   failed_when: "result | failed and result.rc == 1"
   register: result
-  with_items: "{{ scap_profile }}"
+  with_items: "{{ scap_profile_7 }}"
   when: run_scap and ansible_distribution_major_version == "7"
   tags:
     - scap

--- a/tasks/scap.yml
+++ b/tasks/scap.yml
@@ -62,7 +62,7 @@
   shell: /sbin/augenrules --load
 
 - name: Run an SCAP scan and Generate Report EL 6
-  command: /usr/bin/oscap xccdf eval --profile "{{ item }}" --results /tmp/scap_reports/scan-xccdf-results-{{ ansible_date_time.iso8601  }}-{{ item }}.xml --report /tmp/scap_reports/scan-xccdf-report-{{ ansible_date_time.iso8601  }}-{{ item }}.html  /usr/share/xml/scap/ssg/content/ssg-rhel{{ ansible_distribution_major_version }}-xccdf.xml
+  command: /usr/bin/oscap xccdf eval --profile "{{ item }}" --results /tmp/scap_reports/scan-xccdf-results-{{ ansible_date_time.iso8601  }}-{{ item }}.xml --fetch-remote-resources --report /tmp/scap_reports/scan-xccdf-report-{{ ansible_date_time.iso8601  }}-{{ item }}.html  /usr/share/xml/scap/ssg/content/ssg-rhel{{ ansible_distribution_major_version }}-xccdf.xml
   failed_when: "result | failed and 'This content points out to the remote resources' not in result.stdout"
   register: result
   with_items: "{{ scap_profile }}"
@@ -71,7 +71,7 @@
     - scap
 
 - name: Run an SCAP scan and Generate Report EL 7
-  command: /usr/bin/oscap xccdf eval --profile "{{ item }}" --results /tmp/scap_reports/scan-xccdf-results-{{ ansible_date_time.iso8601  }}-{{ item }}.xml --report /tmp/scap_reports/scan-xccdf-report-{{ ansible_date_time.iso8601  }}-{{ item }}.html  /usr/share/xml/scap/ssg/content/ssg-rhel{{ ansible_distribution_major_version }}-xccdf.xml
+  command: /usr/bin/oscap xccdf eval --profile "{{ item }}" --results /tmp/scap_reports/scan-xccdf-results-{{ ansible_date_time.iso8601  }}-{{ item }}.xml --fetch-remote-resources --report /tmp/scap_reports/scan-xccdf-report-{{ ansible_date_time.iso8601  }}-{{ item }}.html  /usr/share/xml/scap/ssg/content/ssg-rhel{{ ansible_distribution_major_version }}-xccdf.xml
   failed_when: "result | failed and result.rc == 1"
   register: result
   with_items: "{{ scap_profile }}"


### PR DESCRIPTION
Ken,

I noticed that the available STIG profiles have changed, for RHEL 7.  Now, the new default profile should be `stig-rhel7-disa`, instead of the old `stig-rhel7-server-upstream`.  Also, the `--fetch-remote-resources` flag is now necessary.

As per our discussion.

- Alex